### PR TITLE
Add `Base.position` for `BufferedOutputStream`

### DIFF
--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -165,6 +165,10 @@ function Base.eof(stream::BufferedOutputStream)
     return true
 end
 
+function Base.position(stream::BufferedOutputStream)
+    return max(0, position(stream.sink) + stream.position - 1)
+end
+
 function Base.pointer(stream::BufferedOutputStream, index::Integer = 1)
     return pointer(stream.buffer, stream.position + index - 1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -516,6 +516,30 @@ end
         end
     end
 
+    @testset "position" begin
+        iob = IOBuffer()
+        sink = IOBuffer()
+        stream = BufferedOutputStream(sink, 16)
+        for len in 0:10:100
+            write(stream, repeat("x", len))
+            write(iob, repeat("x", len))
+            @test position(stream) == position(iob)
+        end
+        close(stream)
+        close(iob)
+        @test position(stream) == position(sink) == position(iob)
+
+        mktemp() do path, sink
+            stream = BufferedOutputStream(sink, 16)
+            pos = 0
+            for len in 0:10:100
+                write(stream, repeat("x", len))
+                pos += len
+                @test position(stream) == pos
+            end
+        end
+    end
+
     @testset "misc." begin
         stream = BufferedOutputStream(IOBuffer(), 5)
         @test eof(stream)


### PR DESCRIPTION
Even if we can't seek or skip through `BufferedOutputStream`, one might want to know how many bytes have been written to the stream.