### PR TITLE
seek should return the stream

### DIFF
--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -354,6 +354,7 @@ function Base.seek(stream::BufferedInputStream{T}, pos::Integer) where T
             string("Can't seek in input stream with source of type ", T)))
         # TODO: Allow seeking forwards by just reading and discarding input
     end
+    return stream
 end
 
 function Base.isopen(stream::BufferedInputStream)

--- a/src/emptystream.jl
+++ b/src/emptystream.jl
@@ -46,6 +46,7 @@ function Base.seek(stream::BufferedInputStream{EmptyStream}, pos::Integer)
     else
         throw(BoundsError)
     end
+    return stream
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,6 +272,7 @@ end
 
         stream = BufferedInputStream(IOBuffer(data), 1024)
         @test all(Bool[test_seek(stream, p) for p in positions])
+        @test seekstart(stream) === stream
     end
 
     @testset "skip" begin


### PR DESCRIPTION
I noticed that `seek` was not returning the stream, inconsistent with Base:
```jl
julia> using BufferedStreams

julia> io = open("HISTORY.md", "r")
IOStream(<file HISTORY.md>)

julia> seekstart(io) # returns io stream
IOStream(<file HISTORY.md>)

julia> bio = BufferedInputStream(io)
BufferedInputStream{IOStream}(<128.0 KiB buffer, 0% filled>)

julia> seekstart(bio) # BUG: does not return the stream
1
```