### PR TITLE
don't forget to shift anchor at end of buffer

### DIFF
--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -82,7 +82,7 @@ function shiftdata!(stream::BufferedInputStream)
         return 0
     else
         if stream.anchor > 0
-            @assert stream.position ≥ stream.anchor # negative seek is not currently allowed
+            @assert stream.position ≥ stream.anchor
             shift = stream.anchor - 1
             n = stream.available - shift
             n > 0 && copyto!(stream.buffer, 1, stream.buffer, stream.anchor, n)

--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -81,10 +81,11 @@ function shiftdata!(stream::BufferedInputStream)
     if stream.immobilized
         return 0
     else
-        if stream.anchor > 0 && stream.available - stream.anchor + 1 > 0
+        if stream.anchor > 0
+            @assert stream.position ≥ stream.anchor # negative seek is not currently allowed
             shift = stream.anchor - 1
             n = stream.available - shift
-            copyto!(stream.buffer, 1, stream.buffer, stream.anchor, n)
+            n > 0 && copyto!(stream.buffer, 1, stream.buffer, stream.anchor, n)
             stream.anchor -= shift
         elseif stream.available - stream.position + 1 > 0
             shift = stream.position - 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,15 @@ end
         end
 
         @test all(Bool[test_anchor() for _ in 1:100])
+
+        # issue #78
+        let io = BufferedInputStream(IOBuffer("α∆"), 1)
+            @test read(io, Char) == 'α'
+            mark(io)
+            @test [read(io, UInt8) for _=1:3] == [0xe2, 0x88, 0x86]
+            reset(io)
+            @test read(io, Char) == '∆'
+        end
     end
 
     @testset "seek" begin


### PR DESCRIPTION
Fixes #78: there was a bug where `shiftdata!` was failing to shift the anchor if it is located at the end of the buffer.